### PR TITLE
enable gomodules to fix docker image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN apk --no-cache update && \
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-encryption-provider
 ARG TAG
 COPY . ./
+ENV GO111MODULE=on
 RUN	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags \
     "-X github.com/kubernetes-sigs/aws-encryption-provider/pkg/version.Version=$TAG" \
     -o bin/aws-encryption-provider cmd/server/main.go


### PR DESCRIPTION
add ```ENV GO111MODULE=on``` to Dockerfile to be able to create docker image.
