### PR TITLE
Add additional docs for kops bootstrap 

### DIFF
--- a/KOPS.md
+++ b/KOPS.md
@@ -1,0 +1,128 @@
+
+## Bootstrap AWS encryption provider using kops during cluster creation
+This guide is an extention to bootstrap instruction on README.md
+
+#### Set the `--encryption-provider` flag with kops
+To set the kubernetes `--encryption-provider` flag with kops you must add it to the kops cluster specificition.
+```yaml
+kind: Cluster
+spec:
+  encryptionConfig: true
+
+```
+Also, you need let kops know about the encryption configuration file. To do this you have to create a kops secret with a special `encryptionconfig` flag during cluster creation, in the following order:
+```bash
+kops create -f <path-to-cluster-spec> --state <state-store>
+kops create secret encryptionconfig -f <path-to-encryption-config-file> --state <state-store> --name <cluster-name>
+kops update cluster <cluster-name> --state <state-store> --yes
+```
+#### Permissions
+Ensure master IAM role has permissions to encrypt/decrypt using the kms. You can achieve this
+using additionalIAMPolicies functionality of kops.
+Example:
+```yaml
+kind: Cluster
+spec:
+  additionalPolicies:
+    master: |
+      [
+        {
+          "Effect": "Allow",
+          "Action": [
+            "kms:Decrypt",
+            "kms:Encrypt"
+          ],
+          "Resource": [
+            <arn-of-kms-key>
+          ]
+        }
+      ]
+```
+#### Use Host Network for aws-encryption-provider
+As the CNI plugin is not yet available, you need to add `hostNetwork: true` to pod spec.
+
+#### Update health port for aws-encryption-provider
+When using hostNetwork, the port `8080` used by aws-encryption-provider conflicts with
+kube-apiserver which also requires the same port. To fix this, add `-health-port=:8083`
+to args section like the pod specification below. Also change the port in `containerPort` and `livenessProbe`
+sections.
+
+#### Run the provider at /srv/kubernetes
+Mount the provider at a directory that is already mounted by default e.g. `/srv/kubernetes/socket.sock`. This is a work around mounting a custom path using kops lifecycles. So then your `encryptionConfig` file becomes:
+```yaml
+kind: EncryptionConfiguration
+resources:
+  - resources:
+    - secrets
+    providers:
+    - kms:
+        name: aws-encryption-provider
+        endpoint: unix:///srv/kubernetes/socket.sock
+        cachesize: 1000
+        timeout: 3s
+    - identity: {}
+```
+
+#### Run aws-encryption-provider as static pod
+You need to have encryption provider running before kube-apiserver, and to do that you can
+use [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) functionality. For kops, static pod manifests are available at `/etc/kubernetes/manifests`. You can further use kops file assets functionality to drop 
+the pod specification file in that directory. 
+
+After the above steps, the kops file asset for the pod specification should look like the following:
+```yaml
+kind: Cluster
+spec:
+  fileAssets:
+  - name: aws-encryption-provider.yaml
+    ## Note if not path is specified the default path it /srv/kubernetes/assets/<name>
+    path: /etc/kubernetes/manifests/aws-encryption-provider.yaml
+    roles:
+    - Master
+    content: |
+      apiVersion: v1
+      kind: Pod
+      metadata:
+        name: aws-encryption-provider
+        namespace: kube-system
+      spec:
+        containers:
+        - image: <image-of-aws-provider>
+          name: aws-encryption-provider
+          command:
+          - /aws-encryption-provider
+          - -key=<arn-of-kms-key>
+          - -region=<region-of-kms-key>
+          - -listen=/srv/kubernetes/socket.sock
+          - -health-port=:8083
+          ports:
+          - containerPort: 8083
+            protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8083
+          volumeMounts:
+          - mountPath: /srv/kubernetes
+            name: kmsplugin
+        hostNetwork: true
+        volumes:
+        - name: kmsplugin
+          hostPath:
+            path: /srv/kubernetes
+            type: DirectoryOrCreate
+        nodeSelector:
+          dedicated: master
+        tolerations:
+        - key: dedicated
+          operator: Equal
+          value: master
+          effect: NoSchedule
+```
+Note: The above uses labels to make sure that the pod lives on all the same nodes as the kube-apiserver. The following is the kops specification to implement node labels for the master instance group to go with the above example:
+```yaml
+kind: InstanceGroup
+spec:
+  nodeLabels:
+    dedicated: master
+  role: Master
+```

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ before starting kube-apiserver. For that you need to perform the following high 
 Note: These steps have been verified with [kops](https://github.com/kubernetes/kops) but 
 it should be similar to any other cluster bootstrapping tool.
 
+For exact kops instructions see `KOPS.md`.
+
 #### Run aws-encryption-provider as static pod
 You need to have encryption provider running before kube-apiserver, and to do that you can
 use [static pods](https://kubernetes.io/docs/tasks/administer-cluster/static-pod/) functionality. For kops, static pod manifests are available at `/etc/kubernetes/manifests`. You can further use kops file assets functionality to drop 
@@ -163,6 +165,25 @@ spec:
     hostPath:
       path: /var/run/kmsplugin
       type: DirectoryOrCreate
+```
+
+### Check that the provider plugin is working
+- First we create a secret: `kubectl create secret generic secret1 -n default --from-literal=mykey=mydata`
+- Then we exec into the etcd-server: `kubectl exec -it -n kube-system $(kubectl get pods -n kube-system | grep etcd-manager-main | awk '{print $1}') bash`
+- `cd /opt/etcd-v3.3.10-linux-amd64/`
+- Then check the contents of our secret in etcd store by running the following:
+```
+ETCDCTL_API=3 etcdctl \
+    --key /rootfs/etc/kubernetes/pki/kube-apiserver/etcd-client.key \
+    --cert  /rootfs/etc/kubernetes/pki/kube-apiserver/etcd-client.crt \
+    --cacert /rootfs/etc/kubernetes/pki/kube-apiserver/etcd-ca.crt  \
+    --endpoints "https://etcd-a.internal.${CLUSTER}:4001" get /registry/secrets/default/secret1
+```
+&nbsp;&nbsp;&nbsp;-- output should be something like:
+```
+0m`�He.0�cryption-provider:�1x��%�B���#JP��J���*ȝ���΂@\n�96�^��ۦ�~0| *�H��
+                    `q�*�J�.P��;&~��o#�O�8m��->8L��0�C3���A7�����~���f�V�ܬ���X��_��`�H#�D��z)+�81��qW��y��`�q��}1<LF, ��N��p����i*�aC#E�߸�s������s��l�?�a
+�AźR������.��8H�4�O
 ```
 
 ### Rotation


### PR DESCRIPTION
Added additional documentation to setup the encryption provider at cluster creation using kops. Please let me know if everything make sense or if there are things that you disagree with! This PR is trying to resolve #29. @micahhausler 