### PR TITLE
Fixes wrong name of the kube-apiserver flag

### DIFF
--- a/KOPS.md
+++ b/KOPS.md
@@ -2,8 +2,8 @@
 ## Bootstrap AWS encryption provider using kops during cluster creation
 This guide is an extention to bootstrap instruction on README.md
 
-#### Set the `--encryption-provider` flag with kops
-To set the kubernetes `--encryption-provider` flag with kops you must add it to the kops cluster specificition.
+#### Set the `--encryption-provider-config` flag with kops
+To set the kubernetes `--encryption-provider-config` flag with kops you must add it to the kops cluster specificition.
 ```yaml
 kind: Cluster
 spec:

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ spec:
 
 Once you have deployed the encryption provider on all the same nodes as your API
 servers, you will need to update the kube-apiserver to use the encryption
-provider by setting the `--encryption-provider` flag and with the path to
+provider by setting the `--encryption-provider-config` flag and with the path to
 your encryption configuration file. Below is an example:
 
 ```yaml


### PR DESCRIPTION
According to documentation kube-apiserver does not have flag 'encryption-provider', but rather 'encryption-provider-config'.
Doc reference https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/