### PR TITLE
use vendor directory to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /go/src/sigs.k8s.io/aws-encryption-provider
 ARG TAG
 COPY . ./
 ENV GO111MODULE=on
-RUN	CGO_ENABLED=0 GOOS=linux go build -installsuffix cgo -ldflags \
+RUN	CGO_ENABLED=0 GOOS=linux go build -mod vendor -installsuffix cgo -ldflags \
     "-X sigs.k8s.io/aws-encryption-provider/pkg/version.Version=$TAG" \
     -o bin/aws-encryption-provider cmd/server/main.go
 


### PR DESCRIPTION
this PR overrides #32 . the vendor directory was available but we were not using it to build.