### PR TITLE
Added Gyuho Lee as owner

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -3,7 +3,9 @@ aliases:
     - sethpollack
     - justinsb
     - micahhausler
+    - gyuho
   maintainers:
     - sethpollack
     - justinsb
     - micahhausler
+    - gyuho

--- a/SECURITY_CONTACTS
+++ b/SECURITY_CONTACTS
@@ -13,3 +13,4 @@
 justinsb
 sethpollack
 micahhausler
+gyuho


### PR DESCRIPTION
@gyuho is a member in good standing of the Kubernetes community and is the lead maintainer of etcd. He is also managing the encryption provider integration on EKS.