### PR TITLE
health check KMS API availability

### DIFF
--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -1,0 +1,29 @@
+// Package healthz implements healthz handlers.
+package healthz
+
+import (
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/aws-encryption-provider/pkg/plugin"
+)
+
+// NewHandler returns a new healthz handler.
+func NewHandler(p *plugin.Plugin) http.Handler {
+	return &handler{p: p}
+}
+
+type handler struct {
+	p *plugin.Plugin
+}
+
+func (hd *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	err := hd.p.Health()
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(rw, err)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprint(rw, http.StatusText(http.StatusOK))
+}

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -1,0 +1,99 @@
+package healthz
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"sigs.k8s.io/aws-encryption-provider/pkg/cloud"
+	"sigs.k8s.io/aws-encryption-provider/pkg/plugin"
+	"sigs.k8s.io/aws-encryption-provider/pkg/server"
+)
+
+// TestHealthz tests healthz handlers.
+func TestHealthz(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	tt := []struct {
+		path          string
+		kmsEncryptErr error
+	}{
+		{
+			path:          "/test-healthz-default",
+			kmsEncryptErr: nil,
+		},
+		{
+			path:          "/test-healthz-fail",
+			kmsEncryptErr: errors.New("fail encrypt"),
+		},
+	}
+	for i, entry := range tt {
+		func() {
+			// create temporary unix socket file
+			f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%x", rand.Int63()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := f.Name()
+			f.Close()
+			os.RemoveAll(addr)
+			defer os.RemoveAll(addr)
+			c := &cloud.KMSMock{}
+			c.SetEncryptResp("test", entry.kmsEncryptErr)
+
+			p := plugin.New("test-key", c, nil)
+
+			ready, errc := make(chan struct{}), make(chan error)
+			s := server.New()
+			p.Register(s.Server)
+			defer func() {
+				s.Server.Stop()
+				if err := <-errc; err != nil {
+					t.Fatalf("#%d: unexpected gRPC server stop error %v", i, err)
+				}
+			}()
+			go func() {
+				close(ready)
+				errc <- s.ListenAndServe(addr)
+			}()
+
+			// wait enough for unix socket to be open
+			time.Sleep(time.Second)
+			select {
+			case <-ready:
+			case <-time.After(2 * time.Second):
+				t.Fatal("took too long to start gRPC server")
+			}
+
+			hd := NewHandler(p)
+
+			mux := http.NewServeMux()
+			mux.Handle(entry.path, hd)
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			u := ts.URL + entry.path
+
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			d, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if entry.kmsEncryptErr == nil && string(d) != "OK" {
+				t.Fatalf("#%d: unexpected response %q, expected 'OK'", i, string(d))
+			}
+		}()
+	}
+}

--- a/pkg/plugin/metrics_test.go
+++ b/pkg/plugin/metrics_test.go
@@ -1,0 +1,114 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"go.uber.org/zap"
+	pb "k8s.io/apiserver/pkg/storage/value/encrypt/envelope/v1beta1"
+	"sigs.k8s.io/aws-encryption-provider/pkg/cloud"
+	"sigs.k8s.io/aws-encryption-provider/pkg/server"
+)
+
+// TestMetrics tests /metrics handler.
+func TestMetrics(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+
+	tt := []struct {
+		key        string
+		encryptErr error
+		expects    string
+	}{
+		{
+			key:        "test-key",
+			encryptErr: errors.New("fail"),
+			expects:    `aws_encryption_provider_kms_operations_total{key_arn="test-key",operation="encrypt",status="failure"} 1`,
+		},
+		{
+			key:        "test-key-throttle",
+			encryptErr: awserr.New("RequestLimitExceeded", "test", errors.New("fail")),
+			expects:    `aws_encryption_provider_kms_operations_total{key_arn="test-key-throttle",operation="encrypt",status="failure-throttle"} 1`,
+		},
+	}
+	for i, entry := range tt {
+		func() {
+			// create temporary unix socket file
+			f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%x", rand.Int63()))
+			if err != nil {
+				t.Fatal(err)
+			}
+			addr := f.Name()
+			f.Close()
+			os.RemoveAll(addr)
+			defer os.RemoveAll(addr)
+			c := &cloud.KMSMock{}
+			c.SetEncryptResp("test", entry.encryptErr)
+
+			p := New(entry.key, c, nil)
+
+			ready, errc := make(chan struct{}), make(chan error)
+			s := server.New()
+			p.Register(s.Server)
+			defer func() {
+				s.Server.Stop()
+				if err := <-errc; err != nil {
+					t.Fatalf("unexpected gRPC server stop error %v", err)
+				}
+			}()
+			go func() {
+				close(ready)
+				errc <- s.ListenAndServe(addr)
+			}()
+
+			// wait enough for unix socket to be open
+			time.Sleep(time.Second)
+			select {
+			case <-ready:
+			case <-time.After(2 * time.Second):
+				t.Fatal("took too long to start gRPC server")
+			}
+
+			mux := http.NewServeMux()
+			mux.Handle("/metrics", promhttp.Handler())
+
+			ts := httptest.NewServer(mux)
+			defer ts.Close()
+
+			u := ts.URL + "/metrics"
+
+			_, err = p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("hello")})
+			if err != nil {
+				if entry.encryptErr == nil {
+					t.Fatal(err)
+				}
+				if !strings.Contains(err.Error(), entry.encryptErr.Error()) {
+					t.Fatalf("#%d: unexpected error %v", i, err)
+				}
+			}
+
+			resp, err := http.Get(u)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			d, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(string(d), entry.expects) {
+				t.Fatalf("#%d: expected %q, got\n\n%s\n\n", i, entry.expects, string(d))
+			}
+		}()
+	}
+}


### PR DESCRIPTION
gRPC server version check doesn't tell much about KMS API availability.
Adding deep health check to test `kms:Encrypt` calls.