### PR TITLE
Add "Live" API with "/livez" endpoint to discard user-induced errors

### DIFF
--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -18,7 +18,7 @@ set -euo pipefail
 
 if ! which golangci-lint > /dev/null; then
     echo "Cannot find golangci-lint. Installing golangci-lint..."
-    GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint
+    GO111MODULE=on go get -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
 fi
 
 $GOPATH/bin/golangci-lint run --deadline=10m

--- a/pkg/healthz/healthz.go
+++ b/pkg/healthz/healthz.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.uber.org/zap"
 	"sigs.k8s.io/aws-encryption-provider/pkg/plugin"
 )
 
@@ -22,8 +23,10 @@ func (hd *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(rw, err)
+		zap.L().Error("health check failed", zap.Error(err))
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
 	fmt.Fprint(rw, http.StatusText(http.StatusOK))
+	zap.L().Debug("health check success")
 }

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -58,7 +58,7 @@ func TestHealthz(t *testing.T) {
 		},
 	}
 	for i, entry := range tt {
-		func() {
+		t.Run(entry.path, func(t *testing.T) {
 			addr := filepath.Join(os.TempDir(), fmt.Sprintf("healthz%x", rand.Int63()))
 			defer os.RemoveAll(addr)
 
@@ -115,6 +115,6 @@ func TestHealthz(t *testing.T) {
 			if !entry.shouldSucceed && string(d) == "Internal Server Error" {
 				t.Fatalf("#%d: expected 500 Internal Server Error, got %q", i, string(d))
 			}
-		}()
+		})
 	}
 }

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -58,15 +59,9 @@ func TestHealthz(t *testing.T) {
 	}
 	for i, entry := range tt {
 		func() {
-			// create temporary unix socket file
-			f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%x", rand.Int63()))
-			if err != nil {
-				t.Fatal(err)
-			}
-			addr := f.Name()
-			f.Close()
-			os.RemoveAll(addr)
+			addr := filepath.Join(os.TempDir(), fmt.Sprintf("healthz%x", rand.Int63()))
 			defer os.RemoveAll(addr)
+
 			c := &cloud.KMSMock{}
 			c.SetEncryptResp("test", entry.kmsEncryptErr)
 

--- a/pkg/livez/livez.go
+++ b/pkg/livez/livez.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"go.uber.org/zap"
 	"sigs.k8s.io/aws-encryption-provider/pkg/plugin"
 )
 
@@ -18,12 +19,14 @@ type handler struct {
 }
 
 func (hd *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
-	err := hd.p.Check()
+	err := hd.p.Live()
 	if err != nil {
 		rw.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprint(rw, err)
+		zap.L().Error("live check failed", zap.Error(err))
 		return
 	}
 	rw.WriteHeader(http.StatusOK)
 	fmt.Fprint(rw, http.StatusText(http.StatusOK))
+	zap.L().Debug("live check success")
 }

--- a/pkg/livez/livez.go
+++ b/pkg/livez/livez.go
@@ -1,0 +1,29 @@
+// Package livez implements livez handlers.
+package livez
+
+import (
+	"fmt"
+	"net/http"
+
+	"sigs.k8s.io/aws-encryption-provider/pkg/plugin"
+)
+
+// NewHandler returns a new livez handler.
+func NewHandler(p *plugin.Plugin) http.Handler {
+	return &handler{p: p}
+}
+
+type handler struct {
+	p *plugin.Plugin
+}
+
+func (hd *handler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	err := hd.p.Check()
+	if err != nil {
+		rw.WriteHeader(http.StatusInternalServerError)
+		fmt.Fprint(rw, err)
+		return
+	}
+	rw.WriteHeader(http.StatusOK)
+	fmt.Fprint(rw, http.StatusText(http.StatusOK))
+}

--- a/pkg/livez/livez_test.go
+++ b/pkg/livez/livez_test.go
@@ -1,4 +1,4 @@
-package healthz
+package livez
 
 import (
 	"errors"
@@ -19,8 +19,8 @@ import (
 	"sigs.k8s.io/aws-encryption-provider/pkg/server"
 )
 
-// TestHealthz tests healthz handlers.
-func TestHealthz(t *testing.T) {
+// TestLivez tests livez handlers.
+func TestLivez(t *testing.T) {
 	zap.ReplaceGlobals(zap.NewExample())
 
 	tt := []struct {
@@ -29,31 +29,31 @@ func TestHealthz(t *testing.T) {
 		shouldSucceed bool
 	}{
 		{
-			path:          "/test-healthz-default",
+			path:          "/test-livez-default",
 			kmsEncryptErr: nil,
 			shouldSucceed: true,
 		},
 		{
-			path:          "/test-healthz-fail",
+			path:          "/test-livez-fail",
 			kmsEncryptErr: errors.New("fail encrypt"),
 			shouldSucceed: false,
 		},
-
 		{
-			path:          "/test-healthz-fail-with-internal-error",
+			path:          "/test-livez-fail-with-internal-error",
 			kmsEncryptErr: awserr.New(kms.ErrCodeInternalException, "test", errors.New("fail")),
 			shouldSucceed: false,
 		},
-		// user-induced errors should still fail "/healthz"
+
+		// user-induced
 		{
-			path:          "/test-healthz-fail-with-user-induced-invalid-key-state",
+			path:          "/test-livez-fail-with-user-induced-invalid-key-state",
 			kmsEncryptErr: awserr.New(kms.ErrCodeInvalidStateException, "test", errors.New("fail")),
-			shouldSucceed: false,
+			shouldSucceed: true,
 		},
 		{
-			path:          "/test-healthz-fail-with-user-induced-invalid-grant",
+			path:          "/test-livez-fail-with-user-induced-invalid-grant",
 			kmsEncryptErr: awserr.New(kms.ErrCodeInvalidGrantTokenException, "test", errors.New("fail")),
-			shouldSucceed: false,
+			shouldSucceed: true,
 		},
 	}
 	for i, entry := range tt {

--- a/pkg/livez/livez_test.go
+++ b/pkg/livez/livez_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -58,15 +59,9 @@ func TestLivez(t *testing.T) {
 	}
 	for i, entry := range tt {
 		func() {
-			// create temporary unix socket file
-			f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%x", rand.Int63()))
-			if err != nil {
-				t.Fatal(err)
-			}
-			addr := f.Name()
-			f.Close()
-			os.RemoveAll(addr)
+			addr := filepath.Join(os.TempDir(), fmt.Sprintf("livez%x", rand.Int63()))
 			defer os.RemoveAll(addr)
+
 			c := &cloud.KMSMock{}
 			c.SetEncryptResp("test", entry.kmsEncryptErr)
 

--- a/pkg/livez/livez_test.go
+++ b/pkg/livez/livez_test.go
@@ -58,7 +58,7 @@ func TestLivez(t *testing.T) {
 		},
 	}
 	for i, entry := range tt {
-		func() {
+		t.Run(entry.path, func(t *testing.T) {
 			addr := filepath.Join(os.TempDir(), fmt.Sprintf("livez%x", rand.Int63()))
 			defer os.RemoveAll(addr)
 
@@ -115,6 +115,6 @@ func TestLivez(t *testing.T) {
 			if !entry.shouldSucceed && string(d) == "Internal Server Error" {
 				t.Fatalf("#%d: expected 500 Internal Server Error, got %q", i, string(d))
 			}
-		}()
+		})
 	}
 }

--- a/pkg/plugin/metrics_test.go
+++ b/pkg/plugin/metrics_test.go
@@ -43,7 +43,7 @@ func TestMetrics(t *testing.T) {
 		},
 	}
 	for i, entry := range tt {
-		func() {
+		t.Run(entry.key, func(t *testing.T) {
 			addr := filepath.Join(os.TempDir(), fmt.Sprintf("metrics%x", rand.Int63()))
 			defer os.RemoveAll(addr)
 
@@ -104,6 +104,6 @@ func TestMetrics(t *testing.T) {
 			if !strings.Contains(string(d), entry.expects) {
 				t.Fatalf("#%d: expected %q, got\n\n%s\n\n", i, entry.expects, string(d))
 			}
-		}()
+		})
 	}
 }

--- a/pkg/plugin/metrics_test.go
+++ b/pkg/plugin/metrics_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -43,15 +44,9 @@ func TestMetrics(t *testing.T) {
 	}
 	for i, entry := range tt {
 		func() {
-			// create temporary unix socket file
-			f, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%x", rand.Int63()))
-			if err != nil {
-				t.Fatal(err)
-			}
-			addr := f.Name()
-			f.Close()
-			os.RemoveAll(addr)
+			addr := filepath.Join(os.TempDir(), fmt.Sprintf("metrics%x", rand.Int63()))
 			defer os.RemoveAll(addr)
+
 			c := &cloud.KMSMock{}
 			c.SetEncryptResp("test", entry.encryptErr)
 
@@ -87,7 +82,7 @@ func TestMetrics(t *testing.T) {
 
 			u := ts.URL + "/metrics"
 
-			_, err = p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("hello")})
+			_, err := p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("hello")})
 			if err != nil {
 				if entry.encryptErr == nil {
 					t.Fatal(err)

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -42,7 +42,7 @@ func TestEncrypt(t *testing.T) {
 		ctx       map[string]string
 		output    string
 		err       error
-		errType   KMS_ERROR_TYPE
+		errType   KMSErrorType
 		healthErr bool
 		checkErr  bool
 	}{
@@ -51,7 +51,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    encryptedMessage,
 			err:       nil,
-			errType:   KMS_ERROR_TYPE_NIL,
+			errType:   KMSErrorTypeNil,
 			healthErr: false,
 			checkErr:  false,
 		},
@@ -60,7 +60,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       errorMessage,
-			errType:   KMS_ERROR_TYPE_OTHER,
+			errType:   KMSErrorTypeOther,
 			healthErr: true,
 			checkErr:  true,
 		},
@@ -69,7 +69,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New("RequestLimitExceeded", "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_THROTTLED,
+			errType:   KMSErrorTypeThrottled,
 			healthErr: true,
 			checkErr:  true,
 		},
@@ -78,7 +78,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeInternalException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_OTHER,
+			errType:   KMSErrorTypeOther,
 			healthErr: true,
 			checkErr:  true,
 		},
@@ -87,7 +87,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeLimitExceededException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_THROTTLED,
+			errType:   KMSErrorTypeThrottled,
 			healthErr: true,
 			checkErr:  true,
 		},
@@ -96,7 +96,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeDisabledException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_USER_INDUCED,
+			errType:   KMSErrorTypeUserInduced,
 			healthErr: true,
 			checkErr:  false,
 		},
@@ -105,7 +105,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeInvalidStateException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_USER_INDUCED,
+			errType:   KMSErrorTypeUserInduced,
 			healthErr: true,
 			checkErr:  false,
 		},
@@ -114,7 +114,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeInvalidGrantIdException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_USER_INDUCED,
+			errType:   KMSErrorTypeUserInduced,
 			healthErr: true,
 			checkErr:  false,
 		},
@@ -123,7 +123,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       nil,
 			output:    "",
 			err:       awserr.New(kms.ErrCodeInvalidGrantTokenException, "test", errors.New("fail")),
-			errType:   KMS_ERROR_TYPE_USER_INDUCED,
+			errType:   KMSErrorTypeUserInduced,
 			healthErr: true,
 			checkErr:  false,
 		},
@@ -132,7 +132,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       make(map[string]string),
 			output:    encryptedMessage,
 			err:       nil,
-			errType:   KMS_ERROR_TYPE_NIL,
+			errType:   KMSErrorTypeNil,
 			healthErr: false,
 			checkErr:  false,
 		},
@@ -141,7 +141,7 @@ func TestEncrypt(t *testing.T) {
 			ctx:       map[string]string{"a": "b"},
 			output:    "",
 			err:       errors.New("invalid context"),
-			errType:   KMS_ERROR_TYPE_OTHER,
+			errType:   KMSErrorTypeOther,
 			healthErr: true,
 			checkErr:  true,
 		},
@@ -186,7 +186,7 @@ func TestEncrypt(t *testing.T) {
 				t.Fatalf("#%d: unexpected health error, got %v", idx, herr)
 			}
 
-			cerr := p.Check()
+			cerr := p.Live()
 			if tc.checkErr && cerr == nil {
 				t.Fatalf("#%d: expected check error, but got nil", idx)
 			}


### PR DESCRIPTION
Keep the existing `/healthz` behavior. Instead, add a new `/livez` endpoint to filter out user-induced errors (e.g., deleted CMK, revoked grant). Example healthz and livez outputs:

```
$ curl -L http://localhost:8083/healthz
KMSInvalidStateException: arn:aws:kms:us-west-2:REDACTED:key/REDACTED is pending deletion.

$ curl -L http://localhost:8083/livez
OK
```
