### PR TITLE
upgrading to minimal base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+FROM public.ecr.aws/eks-distro/kubernetes/go-runner:v0.13.0-eks-1-23-1 as go-runner
 
-FROM golang:1.15-alpine AS build
-RUN apk --no-cache update && \
-    apk --no-cache add ca-certificates git && \
-    rm -rf /var/cache/apk/*
+FROM public.ecr.aws/bitnami/golang:latest AS build
 WORKDIR /go/src/sigs.k8s.io/aws-encryption-provider
 ARG TAG
 COPY . ./
@@ -21,7 +19,7 @@ RUN	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags \
     "-w -s -X sigs.k8s.io/aws-encryption-provider/pkg/version.Version=$TAG" \
     -o bin/aws-encryption-provider cmd/server/main.go
 
-FROM busybox AS aws-encryption-provider
-COPY --from=build /etc/ssl/certs/ /etc/ssl/certs/
+FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest
 COPY --from=build /go/src/sigs.k8s.io/aws-encryption-provider/bin/aws-encryption-provider /aws-encryption-provider
+COPY --from=go-runner /go-runner /go-runner
 ENTRYPOINT ["/aws-encryption-provider"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,3 +23,4 @@ RUN	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags \
 FROM ${BASE_IMAGE}
 COPY --from=build /go/src/sigs.k8s.io/aws-encryption-provider/bin/aws-encryption-provider /aws-encryption-provider
 ENTRYPOINT ["/go-runner"]
+CMD ["/aws-encryption-provider"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM public.ecr.aws/eks-distro/kubernetes/go-runner:v0.13.0-eks-1-23-1 as go-runner
+ARG BUILDER=golang:1.15-alpine
+ARG BASE_IMAGE=public.ecr.aws/eks-distro/kubernetes/go-runner:v0.13.0-eks-1-23-1
 
-FROM public.ecr.aws/bitnami/golang:latest AS build
+FROM ${BUILDER} AS build
 WORKDIR /go/src/sigs.k8s.io/aws-encryption-provider
 ARG TAG
 COPY . ./
@@ -19,7 +20,6 @@ RUN	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags \
     "-w -s -X sigs.k8s.io/aws-encryption-provider/pkg/version.Version=$TAG" \
     -o bin/aws-encryption-provider cmd/server/main.go
 
-FROM public.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base:latest
+FROM ${BASE_IMAGE}
 COPY --from=build /go/src/sigs.k8s.io/aws-encryption-provider/bin/aws-encryption-provider /aws-encryption-provider
-COPY --from=go-runner /go-runner /go-runner
 ENTRYPOINT ["/aws-encryption-provider"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ RUN	CGO_ENABLED=0 GOOS=linux go build -mod vendor -ldflags \
 
 FROM ${BASE_IMAGE}
 COPY --from=build /go/src/sigs.k8s.io/aws-encryption-provider/bin/aws-encryption-provider /aws-encryption-provider
-ENTRYPOINT ["/aws-encryption-provider"]
+ENTRYPOINT ["/go-runner"]


### PR DESCRIPTION
Upgrading the image used in the Dockerfile to minimal base image

Testing:
For testing, the new image was created and built, and tested on Kubernetes versions 1.19 - 1.23.
The manifest was modified to support the newer way of using go-runner.
```
command:
    - /go-runner
    - --log-file=XXXXXX
    - --also-stdout=false
    - --redirect-stderr=true
    - /aws-encryption-provider
    - --region=XXXXXX
    - --encryption-context=XXXXXXXX
    - --key=XXXXXXXX
    - --qps-limit=XXXx
    - --burst-limit=XXXX
    - --listen=XXXXXX
    - --health-port=XXXXXX
```