### PR TITLE
add a clean-up for the unix domain socket before listen on it

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -1,0 +1,59 @@
+package server
+
+import (
+	"log"
+	"os"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+func TestListenAndServe(t *testing.T) {
+	zap.ReplaceGlobals(zap.NewExample())
+	dir, err := os.MkdirTemp("", "")
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer os.RemoveAll(dir) // clean up
+	tt := []struct {
+		addr   string
+		retErr error
+	}{
+		{
+			addr:   dir + "/fileNonExists.sock",
+			retErr: nil,
+		},
+		{
+			addr:   dir + "/fileExists.sock",
+			retErr: nil,
+		},
+		{
+			addr:   ":8080",
+			retErr: nil,
+		},
+	}
+	for _, entry := range tt {
+		t.Run(entry.addr, func(t *testing.T) {
+			ch := make(chan error, 1)
+			s := New()
+			os.Remove(entry.addr)
+			if entry.addr == (dir + "/fileExists.sock") {
+				os.Create(entry.addr)
+				time.Sleep(3 * time.Second)
+			}
+			go func(addr string) {
+				ch <- s.ListenAndServe(addr)
+			}(entry.addr)
+			select {
+			case err := <-ch:
+				if err != entry.retErr {
+					t.Errorf("ListenAndServe() error = %v, wantErr %v", err, entry.retErr)
+				}
+				return
+			case <-time.After(time.Second * 3):
+				break
+			}
+		})
+	}
+}


### PR DESCRIPTION
The existing code didn't check if the socket file exists or not. In the scenario when the file has already exists, Listen failed.

This PR adds a clean-up for the unix domain socket file before listening on it.