### PR TITLE
Fix goreleaser --skip-publish flag deprecation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,4 +25,4 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --snapshot --skip-publish --rm-dist
+          args: release --snapshot --skip=publish --clean

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v3
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
* --skip-publish was replaced with --skip=publish
* --rm-dist was replaced with --clean

https://goreleaser.com/deprecations/#-skip
https://goreleaser.com/deprecations/#-rm-dist

This resolves the CI failure in #120 