### PR TITLE
Update golangci-lint to fix aws-sdk-go-v2 linting issues

### DIFF
--- a/cmd/client/main.go
+++ b/cmd/client/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	ctx := context.Background()
 
+	//nolint:staticcheck
 	vReq := &pb.VersionRequest{}
 	vRes, err := client.Version(ctx, vReq)
 	if err != nil {
@@ -66,6 +67,7 @@ func main() {
 
 		switch splits[0] {
 		case "encrypt":
+			//nolint:staticcheck
 			eReq := &pb.EncryptRequest{Plain: []byte(splits[1])}
 			res, err := client.Encrypt(ctx, eReq)
 			if err != nil {
@@ -77,6 +79,7 @@ func main() {
 			if err != nil {
 				log.Fatalf("Failed to decode: %v", err)
 			}
+			//nolint:staticcheck
 			dReq := &pb.DecryptRequest{Cipher: b}
 			res, err := client.Decrypt(ctx, dReq)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -37,21 +37,3 @@ require (
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/go-critic/go-critic v0.0.0-20181204210945-1df300866540 => github.com/go-critic/go-critic v0.0.0-20190526074819-1df300866540
-
-replace github.com/golangci/errcheck v0.0.0-20181003203344-ef45e06d44b6 => github.com/golangci/errcheck v0.0.0-20181223084120-ef45e06d44b6
-
-replace github.com/golangci/go-tools v0.0.0-20180109140146-af6baa5dc196 => github.com/golangci/go-tools v0.0.0-20190318060251-af6baa5dc196
-
-replace github.com/golangci/gofmt v0.0.0-20181105071733-0b8337e80d98 => github.com/golangci/gofmt v0.0.0-20181222123516-0b8337e80d98
-
-replace github.com/golangci/gosec v0.0.0-20180901114220-66fb7fc33547 => github.com/golangci/gosec v0.0.0-20190211064107-66fb7fc33547
-
-replace github.com/golangci/ineffassign v0.0.0-20180808204949-42439a7714cc => github.com/golangci/ineffassign v0.0.0-20190609212857-42439a7714cc
-
-replace github.com/golangci/lint-1 v0.0.0-20180610141402-ee948d087217 => github.com/golangci/lint-1 v0.0.0-20190420132249-ee948d087217
-
-replace github.com/timakin/bodyclose => github.com/golangci/bodyclose v0.0.0-20190714144026-65da19158fa2
-
-replace mvdan.cc/unparam v0.0.0-20190124213536-fbb59629db34 => mvdan.cc/unparam v0.0.0-20190209190245-fbb59629db34

--- a/hack/verify-golint.sh
+++ b/hack/verify-golint.sh
@@ -22,9 +22,9 @@ go version
 
 if ! which golangci-lint > /dev/null; then
     echo "Cannot find golangci-lint. Installing golangci-lint..."
-    GO111MODULE=on go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.41.1
+    GO111MODULE=on go install -v github.com/golangci/golangci-lint/cmd/golangci-lint@v1.61.0
 fi
 
-$GOPATH/bin/golangci-lint run --deadline=10m
+$(go env GOPATH)/bin/golangci-lint run --timeout=10m
 
 echo "Congratulations! All Go source files have been linted."

--- a/pkg/connection/connection.go
+++ b/pkg/connection/connection.go
@@ -1,9 +1,7 @@
 package connection
 
 import (
-	"context"
 	"fmt"
-	"net"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
@@ -11,13 +9,8 @@ import (
 
 // New returns a grpc client connection for a given unix socket file path
 func New(addr string) (*grpc.ClientConn, error) {
-	dialer := func(ctx context.Context, addr string) (net.Conn, error) {
-		var d net.Dialer
-		return d.DialContext(ctx, "unix", addr)
-	}
-
-	conn, err := grpc.Dial(
-		addr, grpc.WithContextDialer(dialer),
+	conn, err := grpc.NewClient(
+		"unix://"+addr,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {

--- a/pkg/plugin/metrics_test.go
+++ b/pkg/plugin/metrics_test.go
@@ -84,6 +84,7 @@ func TestMetrics(t *testing.T) {
 
 			u := ts.URL + "/metrics"
 
+			//nolint:staticcheck
 			_, err := p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("hello")})
 			if err != nil {
 				if entry.encryptErr == nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -90,6 +90,7 @@ func newPlugin(
 func (p *V1Plugin) Health() error {
 	recent, err := p.healthCheck.isRecentlyChecked()
 	if !recent {
+		//nolint:staticcheck
 		_, err = p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("foo")})
 		p.healthCheck.recordErr(err)
 		if err != nil {
@@ -116,7 +117,10 @@ func (p *V1Plugin) Live() error {
 }
 
 // Version returns the V1Plugin server version
+//
+//nolint:staticcheck
 func (p *V1Plugin) Version(ctx context.Context, request *pb.VersionRequest) (*pb.VersionResponse, error) {
+	//nolint:staticcheck
 	return &pb.VersionResponse{
 		Version:        version.APIVersion,
 		RuntimeName:    version.Runtime,
@@ -125,6 +129,8 @@ func (p *V1Plugin) Version(ctx context.Context, request *pb.VersionRequest) (*pb
 }
 
 // Encrypt executes the encryption operation using AWS KMS
+//
+//nolint:staticcheck
 func (p *V1Plugin) Encrypt(ctx context.Context, request *pb.EncryptRequest) (*pb.EncryptResponse, error) {
 	zap.L().Debug("starting encrypt operation")
 
@@ -154,10 +160,13 @@ func (p *V1Plugin) Encrypt(ctx context.Context, request *pb.EncryptRequest) (*pb
 	zap.L().Debug("encrypt operation successful")
 	kmsLatencyMetric.WithLabelValues(p.keyID, kmsplugin.StatusSuccess, kmsplugin.OperationEncrypt, GRPC_V1).Observe(kmsplugin.GetMillisecondsSince(startTime))
 	kmsOperationCounter.WithLabelValues(p.keyID, kmsplugin.StatusSuccess, kmsplugin.OperationEncrypt, GRPC_V1).Inc()
+	//nolint:staticcheck
 	return &pb.EncryptResponse{Cipher: append([]byte(kmsplugin.StorageVersion), result.CiphertextBlob...)}, nil
 }
 
 // Decrypt executes the decrypt operation using AWS KMS
+//
+//nolint:staticcheck
 func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb.DecryptResponse, error) {
 	zap.L().Debug("starting decrypt operation")
 
@@ -189,6 +198,7 @@ func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 	zap.L().Debug("decrypt operation successful")
 	kmsLatencyMetric.WithLabelValues(p.keyID, kmsplugin.StatusSuccess, kmsplugin.OperationDecrypt, GRPC_V1).Observe(kmsplugin.GetMillisecondsSince(startTime))
 	kmsOperationCounter.WithLabelValues(p.keyID, kmsplugin.StatusSuccess, kmsplugin.OperationDecrypt, GRPC_V1).Inc()
+	//nolint:staticcheck
 	return &pb.DecryptResponse{Plain: result.Plaintext}, nil
 }
 
@@ -204,6 +214,7 @@ func WaitForReady(client pb.KeyManagementServiceClient, duration time.Duration) 
 	ctx, cancel := context.WithTimeout(context.Background(), duration)
 	defer cancel()
 
+	//nolint:staticcheck
 	_, err := client.Version(ctx, &pb.VersionRequest{}, grpc.WaitForReady(true))
 	if err != nil {
 		return err

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -180,6 +180,7 @@ func TestEncrypt(t *testing.T) {
 				sharedHealthCheck.Stop()
 			}()
 
+			//nolint:staticcheck
 			eReq := &pb.EncryptRequest{Plain: []byte(tc.input)}
 			eRes, err := p.Encrypt(ctx, eReq)
 
@@ -258,6 +259,7 @@ func TestDecrypt(t *testing.T) {
 				sharedHealthCheck.Stop()
 			}()
 
+			//nolint:staticcheck
 			dReq := &pb.DecryptRequest{Cipher: []byte(tc.input)}
 			dRes, err := p.Decrypt(ctx, dReq)
 
@@ -304,6 +306,7 @@ func TestHealth(t *testing.T) {
 		c.SetEncryptResp("foo", entry.encryptErr)
 		c.SetDecryptResp("foo", entry.decryptErr)
 
+		//nolint:staticcheck
 		_, encErr := p.Encrypt(context.Background(), &pb.EncryptRequest{Plain: []byte("foo")})
 		if entry.encryptErr == nil && encErr != nil {
 			t.Fatalf("#%d: unexpected error from Encrypt %v", idx, encErr)
@@ -317,6 +320,7 @@ func TestHealth(t *testing.T) {
 			t.Fatalf("#%d: unexpected error from Health %v", idx, herr1)
 		}
 
+		//nolint:staticcheck
 		_, decErr := p.Decrypt(context.Background(), &pb.DecryptRequest{Cipher: []byte("foo")})
 		if entry.decryptErr == nil && decErr != nil {
 			t.Fatalf("#%d: unexpected error from Encrypt %v", idx, decErr)
@@ -349,6 +353,7 @@ func TestHealthManyRequests(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		errc := make(chan error)
 		go func() {
+			//nolint:staticcheck
 			_, err := p.Encrypt(
 				context.Background(),
 				&pb.EncryptRequest{Plain: []byte("foo")},

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -101,6 +101,7 @@ func TestEncrypt(t *testing.T) {
 	for _, tc := range tt {
 		mock.SetEncryptResp(tc.output, tc.err)
 
+		//nolint:staticcheck
 		eReq := &pb.EncryptRequest{Plain: []byte(tc.input)}
 		eRes, err := client.Encrypt(ctx, eReq)
 
@@ -163,6 +164,7 @@ func TestDecrypt(t *testing.T) {
 	for _, tc := range tt {
 		mock.SetDecryptResp(tc.output, tc.err)
 
+		//nolint:staticcheck
 		dReq := &pb.DecryptRequest{Cipher: []byte(tc.input)}
 		dRes, err := client.Decrypt(ctx, dReq)
 


### PR DESCRIPTION
* We have been pinning to older versions of many golangci-lint packages that are no longer needed
* Updated golangci-lint to v1.61.0 and change a deprecated --deadline flag to --timeout
* Resolve linter errors - mostly this is ignoring staticcheck for deprecated KMSv1 code that's being intentionally carried
* Replace deprecated `grpc.Dial`/`grpc.DialContext` with `grpc.NewClient` https://pkg.go.dev/google.golang.org/grpc@v1.65.0#Dial

Resolves CI linting failures in #120