### PR TITLE
Don't fail healthcheck on failed decrypts

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -175,10 +175,6 @@ func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 
 	result, err := p.svc.Decrypt(input)
 	if err != nil {
-		select {
-		case p.healthCheck.healthCheckErrc <- err:
-		default:
-		}
 		zap.L().Error("request to decrypt failed", zap.String("error-type", kmsplugin.ParseError(err).String()), zap.Error(err))
 		failLabel := kmsplugin.GetStatusLabel(err)
 		kmsLatencyMetric.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationDecrypt, GRPC_V1).Observe(kmsplugin.GetMillisecondsSince(startTime))

--- a/pkg/plugin/plugin_v2.go
+++ b/pkg/plugin/plugin_v2.go
@@ -183,10 +183,6 @@ func (p *V2Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 
 	result, err := p.svc.Decrypt(input)
 	if err != nil {
-		select {
-		case p.healthCheck.healthCheckErrc <- err:
-		default:
-		}
 		zap.L().Error("request to decrypt failed", zap.String("error-type", kmsplugin.ParseError(err).String()), zap.Error(err))
 		failLabel := kmsplugin.GetStatusLabel(err)
 		kmsLatencyMetric.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationDecrypt, GRPC_V2).Observe(kmsplugin.GetMillisecondsSince(startTime))


### PR DESCRIPTION
With multiple key configurations, it's expected that decrypts could fail for key1 and still succeed for key2. Therefore we shouldn't cache decrypt failures in the healthchecker as this would cause /livez checks to fail.