### PR TITLE
Handle external keystore error as user induced

### DIFF
--- a/pkg/kmsplugin/kms.go
+++ b/pkg/kmsplugin/kms.go
@@ -88,6 +88,11 @@ func ParseError(err error) (errorType KMSErrorType) {
 			strings.Contains(ev.Message(), "does not exist in this region") {
 			return KMSErrorTypeUserInduced
 		}
+	//Some times this error message is returned as part of  KMSInvalidStateException or KMSInternalException
+	case kms.ErrCodeInternalException:
+		if strings.Contains(ev.Message(), "AWS KMS rejected the request because the external key store proxy did not respond in time. Retry the request. If you see this error repeatedly, report it to your external key store proxy administrator") {
+			return KMSErrorTypeUserInduced
+		}
 	}
 
 	return KMSErrorTypeOther

--- a/pkg/plugin/plugin_v2_test.go
+++ b/pkg/plugin/plugin_v2_test.go
@@ -156,6 +156,15 @@ func TestEncryptV2(t *testing.T) {
 			healthErr: true,
 			checkErr:  true,
 		},
+		{
+			input:     plainMessage,
+			ctx:       nil,
+			output:    "",
+			err:       awserr.New(kms.ErrCodeInternalException, "AWS KMS rejected the request because the external key store proxy did not respond in time. Retry the request. If you see this error repeatedly, report it to your external key store proxy administrator.", errors.New("fail")),
+			errType:   kmsplugin.KMSErrorTypeUserInduced,
+			healthErr: true,
+			checkErr:  false,
+		},
 	}
 
 	c := &cloud.KMSMock{}


### PR DESCRIPTION
Sometimes we are seeing the same error as part of 2 exceptions when using external key store. Treat both as user induced.