### PR TITLE
Cloudbuild for releasing official container

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,18 @@
+timeout: 1600s
+
+options:
+  substitution_option: ALLOW_LOOSE
+  dynamic_substitutions: true
+
+steps:
+  - name: 'gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d'
+    entrypoint: make
+    env:
+      - REPO=us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider
+      - TAG=$_GIT_TAG
+    args:
+      - build-docker
+
+substitutions:
+  _GIT_TAG: '12345'
+  _PULL_BASE_REF: 'master'


### PR DESCRIPTION
PR to start publishing official aws-encryption-provider containers. Resolves #71

Followed image-pushing guide in [test-infra](https://github.com/kubernetes/test-infra/blob/master/config/jobs/image-pushing/README.md)

Utilizes existing container repo created from this [PR](https://github.com/kubernetes/k8s.io/pull/7587)

Corresponding job configuration for image pushing [PR](https://github.com/kubernetes/test-infra/pull/34772) in test-infra account