### PR TITLE
fix: failing build due to invalid IMAGE override in container builds

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,7 @@ steps:
     entrypoint: make
     env:
       - REPO=us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider
+      - IMAGE=aws-encryption-provider
       - TAG=$_GIT_TAG
     args:
       - build-docker


### PR DESCRIPTION
Recently merged PR #136 but it leads to build failure due to invalid default IMAGE overrides passed by the build system. 
In this PR we explicitly set the IMAGE variable with the correct image name to ensure the container tag is valid.

Failing build : https://storage.googleapis.com/kubernetes-ci-logs/logs/aws-encryption-provider-push-images/1920901423042662400/build-log.txt

Failure reason:
```
docker buildx build \
	--output=type=docker \
	--platform=linux/amd64 \
	-t us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider/gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d:latest \
	-t us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider/gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d:v20250509-4bb7e48 \
	--build-arg BUILDER=public.ecr.aws/eks-distro-build-tooling/golang:1.24.2-gcc \
	--build-arg TAG=v20250509-4bb7e48 .
ERROR: invalid tag "us-central1-docker.pkg.dev/k8s-staging-images/aws-encryption-provider/gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20250116-2a05ea7e3d:latest": invalid reference format
make: *** [Makefile:21: build-docker] Error 1
```