### PR TITLE
Add metric category for failures due to corruption and remove from he…

### DIFF
--- a/pkg/kmsplugin/kms.go
+++ b/pkg/kmsplugin/kms.go
@@ -80,7 +80,7 @@ func ParseError(err error) (errorType KMSErrorType) {
 	// ref. https://docs.aws.amazon.com/kms/latest/developerguide/requests-per-second.html
 	case (&kmstypes.LimitExceededException{}).ErrorCode():
 		return KMSErrorTypeThrottled
-	
+
 	case (&kmstypes.InvalidCiphertextException{}).ErrorCode():
 		return KMSErrorTypeCorruption
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -187,7 +187,10 @@ func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 	if err != nil {
 		errorType := kmsplugin.ParseError(err).String()
 		if errorType != kmsplugin.KMSErrorTypeCorruption.String() {
-			p.healthCheck.healthCheckErrc <- err
+			select {
+			case p.healthCheck.healthCheckErrc <- err:
+			default:
+			}
 		}
 		zap.L().Error("request to decrypt failed", zap.String("error-type", errorType), zap.Error(err))
 		failLabel := kmsplugin.GetStatusLabel(err, errorType)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -150,8 +150,9 @@ func (p *V1Plugin) Encrypt(ctx context.Context, request *pb.EncryptRequest) (*pb
 		case p.healthCheck.healthCheckErrc <- err:
 		default:
 		}
-		zap.L().Error("request to encrypt failed", zap.String("error-type", kmsplugin.ParseError(err).String()), zap.Error(err))
-		failLabel := kmsplugin.GetStatusLabel(err)
+		errorType := kmsplugin.ParseError(err).String()
+		zap.L().Error("request to encrypt failed", zap.String("error-type", errorType), zap.Error(err))
+		failLabel := kmsplugin.GetStatusLabel(err, errorType)
 		kmsLatencyMetric.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationEncrypt, GRPC_V1).Observe(kmsplugin.GetMillisecondsSince(startTime))
 		kmsOperationCounter.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationEncrypt, GRPC_V1).Inc()
 		return nil, fmt.Errorf("failed to encrypt %w", err)
@@ -184,12 +185,12 @@ func (p *V1Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 
 	result, err := p.svc.Decrypt(ctx, input)
 	if err != nil {
-		select {
-		case p.healthCheck.healthCheckErrc <- err:
-		default:
+		errorType := kmsplugin.ParseError(err).String()
+		if errorType != kmsplugin.KMSErrorTypeCorruption.String() {
+			p.healthCheck.healthCheckErrc <- err
 		}
-		zap.L().Error("request to decrypt failed", zap.String("error-type", kmsplugin.ParseError(err).String()), zap.Error(err))
-		failLabel := kmsplugin.GetStatusLabel(err)
+		zap.L().Error("request to decrypt failed", zap.String("error-type", errorType), zap.Error(err))
+		failLabel := kmsplugin.GetStatusLabel(err, errorType)
 		kmsLatencyMetric.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationDecrypt, GRPC_V1).Observe(kmsplugin.GetMillisecondsSince(startTime))
 		kmsOperationCounter.WithLabelValues(p.keyID, failLabel, kmsplugin.OperationDecrypt, GRPC_V1).Inc()
 		return nil, fmt.Errorf("failed to decrypt %w", err)

--- a/pkg/plugin/plugin_v2.go
+++ b/pkg/plugin/plugin_v2.go
@@ -186,7 +186,10 @@ func (p *V2Plugin) Decrypt(ctx context.Context, request *pb.DecryptRequest) (*pb
 	if err != nil {
 		errorType := kmsplugin.ParseError(err).String()
 		if errorType != kmsplugin.KMSErrorTypeCorruption.String() {
-			p.healthCheck.healthCheckErrc <- err
+			select {
+			case p.healthCheck.healthCheckErrc <- err:
+			default:
+			}
 		}
 		zap.L().Error("request to decrypt failed", zap.String("error-type", errorType), zap.Error(err))
 		failLabel := kmsplugin.GetStatusLabel(err, errorType)

--- a/pkg/plugin/plugin_v2_test.go
+++ b/pkg/plugin/plugin_v2_test.go
@@ -179,13 +179,13 @@ func TestEncryptV2(t *testing.T) {
 			checkErr:  false,
 		},
 		{
-			input: plainMessage,
-			ctx: nil,
-			output: "",
-			err: &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
-			errType: kmsplugin.KMSErrorTypeCorruption,
+			input:     plainMessage,
+			ctx:       nil,
+			output:    "",
+			err:       &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
+			errType:   kmsplugin.KMSErrorTypeCorruption,
 			healthErr: true,
-			checkErr: true,
+			checkErr:  true,
 		},
 	}
 
@@ -302,23 +302,23 @@ func TestHealthV2(t *testing.T) {
 	zap.ReplaceGlobals(zap.NewExample())
 
 	tt := []struct {
-		encryptErr error
-		decryptErr error
+		encryptErr       error
+		decryptErr       error
 		decryptHealthErr bool
 	}{
 		{
-			encryptErr: nil,
-			decryptErr: nil,
+			encryptErr:       nil,
+			decryptErr:       nil,
 			decryptHealthErr: false,
 		},
 		{
-			encryptErr: errors.New("encrypt fail"),
-			decryptErr: errors.New("decrypt fail"),
+			encryptErr:       errors.New("encrypt fail"),
+			decryptErr:       errors.New("decrypt fail"),
 			decryptHealthErr: true,
 		},
 		{
-			encryptErr: nil,
-			decryptErr: &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
+			encryptErr:       nil,
+			decryptErr:       &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
 			decryptHealthErr: false,
 		},
 	}

--- a/pkg/plugin/plugin_v2_test.go
+++ b/pkg/plugin/plugin_v2_test.go
@@ -178,6 +178,15 @@ func TestEncryptV2(t *testing.T) {
 			healthErr: true,
 			checkErr:  false,
 		},
+		{
+			input: plainMessage,
+			ctx: nil,
+			output: "",
+			err: &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
+			errType: kmsplugin.KMSErrorTypeCorruption,
+			healthErr: true,
+			checkErr: true,
+		},
 	}
 
 	c := &cloud.KMSMock{}
@@ -295,14 +304,22 @@ func TestHealthV2(t *testing.T) {
 	tt := []struct {
 		encryptErr error
 		decryptErr error
+		decryptHealthErr bool
 	}{
 		{
 			encryptErr: nil,
 			decryptErr: nil,
+			decryptHealthErr: false,
 		},
 		{
 			encryptErr: errors.New("encrypt fail"),
 			decryptErr: errors.New("decrypt fail"),
+			decryptHealthErr: true,
+		},
+		{
+			encryptErr: nil,
+			decryptErr: &kmstypes.InvalidCiphertextException{Message: aws.String("InvalidCipherException:")},
+			decryptHealthErr: false,
 		},
 	}
 	for idx, entry := range tt {
@@ -335,7 +352,7 @@ func TestHealthV2(t *testing.T) {
 			t.Fatalf("#%d: unexpected error from Encrypt %v", idx, decErr)
 		}
 		herr2 := p.Health()
-		if entry.decryptErr == nil {
+		if !entry.decryptHealthErr {
 			if herr2 != nil {
 				t.Fatalf("#%d: unexpected error from Health %v", idx, herr2)
 			}


### PR DESCRIPTION
Adds new failure category of `KMSErrorTypeCorruption` for when KMS returns `InvalidCiphertextException` as this due to corrupted objects in ETCD. 

When this error is received during decryption, we record the operation metric with `failure-corruption` rather than `failure` so we can easily catch when an object is corrupted in ETCD. 

Additionally, in cases of corruption, we don't add the error to the health check cache as the overall health of encryption-provider is healthy and the core issue is with ETCD.